### PR TITLE
fix register backend

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -26,13 +26,9 @@ use OCP\AppFramework\QueryException;
 
 try {
 	\OC::$server->getCalendarResourceBackendManager()
-		->registerBackend(\OC::$server->query(
-			Integration\ResourceBackend::class
-		));
+		->registerBackend(Integration\ResourceBackend::class);
 	\OC::$server->getCalendarRoomBackendManager()
-		->registerBackend(\OC::$server->query(
-			Integration\RoomBackend::class
-		));
+		->registerBackend(Integration\RoomBackend::class);
 } catch(QueryException $ex) {
 	\OC::$server->getLogger()->logException($ex);
 }


### PR DESCRIPTION
`Argument 1 passed to OC\\Calendar\\Resource\\Manager::registerBackend() must be of the type string, object given, called in /var/www/nextcloud/apps/admin_resource_booking_database/appinfo/app.php on line 30` shows up in Nextcloud 16.

fix #2 